### PR TITLE
NF-695: Only returns active recommended articles back to client

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -32,7 +32,7 @@ ansiColor('xterm') {
                 checkout changelog: false, poll: false, scm: [
                     $class: 'GitSCM',
                     branches: [[
-                        name: 'feature/nf-695-only-return-active-articles'
+                        name: 'master'
                     ]],
                     doGenerateSubmoduleConfigurations: false,
                     extensions: [[

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -32,7 +32,7 @@ ansiColor('xterm') {
                 checkout changelog: false, poll: false, scm: [
                     $class: 'GitSCM',
                     branches: [[
-                        name: 'master'
+                        name: 'feature/nf-695-only-return-active-articles'
                     ]],
                     doGenerateSubmoduleConfigurations: false,
                     extensions: [[
@@ -108,7 +108,7 @@ ansiColor('xterm') {
 
             stage("PreProd Tests"){
                sh """
-                  echo "Running It Tests"
+                  echo "Running It Tests - *** Ignored ***"
                 """
             }
 

--- a/component-test/src/test/resources/recommender/__files/articles.json
+++ b/component-test/src/test/resources/recommender/__files/articles.json
@@ -12,6 +12,12 @@
             "score": 0.8,
             "weight": 1,
             "date-last-modified": "2017-02-07T15:07:56.000Z"
+        },
+        {
+            "content-id": "33333333-3333-3333-3333-333333333333",
+            "score": 0.7,
+            "weight": 1,
+            "date-last-modified": "2017-02-07T15:07:56.000Z"
         }
     ]
 }

--- a/component-test/src/test/resources/storage/__files/content-33333333-3333-3333-3333-333333333333.json
+++ b/component-test/src/test/resources/storage/__files/content-33333333-3333-3333-3333-333333333333.json
@@ -1,0 +1,216 @@
+{
+  "metadata": {
+    "content-id": "33333333-3333-3333-3333-333333333333",
+    "type": "article",
+    "premium": false,
+    "language": "en-gb",
+    "active": false,
+    "tmg-created-date": "2018-09-20T10:50:13.000Z",
+    "tmg-last-modified-date": "2018-09-20T12:45:46.993Z",
+    "source": {
+      "original-source": "Telegraph",
+      "original-feed-name": "pa",
+      "source-id": "d61e69b4-bcc0-11e8-94bb-06d4359927da",
+      "created-date": "2018-09-20T10:50:13.000Z"
+    },
+    "rights": [],
+    "location": [],
+    "annotations": [
+      {
+        "name": "Christopher Williams",
+        "uri": "editors:christopher-williams"
+      },
+      {
+        "name": "20th Century Fox",
+        "uri": "topics:organisations/20th-century-fox"
+      },
+      {
+        "name": "Business",
+        "uri": "structure:business"
+      },
+      {
+        "name": "Companies",
+        "uri": "structure:business/companies"
+      },
+      {
+        "name": "Martin Gilbert",
+        "uri": "topics:people/martin-gilbert"
+      },
+      {
+        "name": "Sky",
+        "uri": "topics:organisations/sky"
+      },
+      {
+        "name": "Registration Wall Content",
+        "uri": "structure:regwall-content"
+      },
+      {
+        "name": "Rupert Murdoch",
+        "uri": "topics:people/rupert-murdoch"
+      },
+      {
+        "name": "Netflix",
+        "uri": "topics:organisations/netflix"
+      },
+      {
+        "name": "Disney",
+        "uri": "topics:things/disney"
+      }
+    ],
+    "extensions": [
+      {
+        "key": "channel",
+        "value": "sports"
+      },
+      {
+        "key": "url",
+        "value": "https://www.telegraph.co.uk/business/2018/09/20/sky-battle-lines-drawn-fox-disney-comcast-prepare-27bn-auction/"
+      },
+      {
+        "key": "pageId",
+        "value": "ArSnNgvfl7LD"
+      },
+      {
+        "key": "authoringId",
+        "value": "d61e69b4-bcc0-11e8-94bb-06d4359927da"
+      },
+      {
+        "key": "tmgId",
+        "value": "m4ywcyltmnxwemdbgu2di4dvojwwsyle"
+      }
+    ]
+  },
+  "content": {
+    "headline": "Sky battle lines drawn as Fox, Disney and Comcast prepare for £27bn auction",
+    "authors": [
+      {
+        "name": "Christopher Williams",
+        "uri": "/authors/christopher-williams/",
+        "url": "https://www.telegraph.co.uk/authors/christopher-williams/"
+      },
+      {
+        "name": "Sophie Christie",
+        "uri": "/authors/sophie-christie/",
+        "url": "https://www.telegraph.co.uk/authors/sophie-christie/"
+      }
+    ],
+    "body": [
+      {
+        "data": "https://www.telegraph.co.uk/content/dam/business/2018/09/20/TELEMMGLPICT000175175560_trans%2B%2BpVlberWd9EgFPZtcLiMQfyf2A9a6I9YchsjMeADBa08.jpeg",
+        "alt-text": "The takeover saga's dramatic finale ranks as the biggest ever such auction",
+        "credit": " Luca Bruno/ AP",
+        "caption": "The takeover saga's dramatic finale ranks as the biggest ever such auction",
+        "html-caption": "The takeover saga's dramatic finale ranks as the biggest ever such auction",
+        "type": "image"
+      },
+      {
+        "data": "The protracted battle over ownership of Sky will be all but settled over 24 hours this weekend in a rare auction in which three global media heavyweights will go three rounds.",
+        "html-data": "<p>The protracted battle over ownership of Sky will be all but settled over 24 hours this weekend in a rare auction in which three global media heavyweights will go three rounds.</p>",
+        "type": "text"
+      },
+      {
+        "data": "Comcast will take on the tag team of 21st Century Fox and Disney, with investors expecting the winning side to value Sky at at least £27bn.",
+        "html-data": "<p>Comcast will take on the tag team of 21st Century Fox and Disney, with investors expecting the winning side to value Sky at at least £27bn.</p>",
+        "type": "text"
+      },
+      {
+        "data": "The Takeover Panel, the City’s regulator of merger processes, will act as referee between the Murdoch family, who contol Fox and will line up alongside Disney chairman Bob Iger, and Brian Roberts, the Comcast chief.",
+        "html-data": "<p>The Takeover Panel, the City’s regulator of merger processes, will act as referee between the Murdoch family, who contol Fox and will line up alongside Disney chairman Bob Iger, and Brian Roberts, the Comcast chief.</p>",
+        "type": "text"
+      },
+      {
+        "data": "The rules of engagement have been drawn up by the Takeover Panel after negotiations with both sides. The auction will formally begin at 5pm on Friday and conclude at the same time on Saturday.",
+        "html-data": "<p>The rules of engagement have&nbsp;been drawn up by the Takeover Panel after negotiations with both sides. The auction will formally begin at 5pm on Friday and conclude at the same time on Saturday.</p>",
+        "type": "text"
+      },
+      {
+        "data": "There will be three rounds of bidding. In the first round, only the contender with the lowest offer going into the auction, currently Disney and Fox, will be able to bid. Comcast has offered £14.75 per share for Sky, ahead of Disney and Fox on £14.",
+        "html-data": "<p>There will be three rounds of bidding. In the first round, only the contender with the lowest offer going into the auction, currently Disney and Fox, will be able to bid. Comcast has offered £14.75 per share for Sky, ahead of Disney and Fox on £14.</p>",
+        "type": "text"
+      },
+      {
+        "data": "In the second round Comcast will be able to respond. If the US cable giant, which also owns Universal, the Hollywood studio behind Jurassic World, does not bid then the auction will conclude with Disney and Fox the winner.",
+        "html-data": "<p>In the second round Comcast will be able to respond. If the US cable giant, which also owns Universal, the Hollywood studio behind Jurassic World, does not bid then the auction will conclude with Disney and Fox the winner.</p>",
+        "type": "text"
+      },
+      {
+        "data": "However, if Comcast does hit back with a better offer, then there will be a final round in which both sides will be able to make their best and final offers.",
+        "html-data": "<p>However, if Comcast does hit back with a better offer, then there will be a final round in which both&nbsp;sides will be able to make their best and final offers.</p>",
+        "type": "text"
+      },
+      {
+        "data": "<iframe layout=\"responsive\" sandbox=\"allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms\" resizable=\"\" src=\"https://cf-particle-html.eip.telegraph.co.uk/e480178c-5d1d-4f75-8058-e19a92620d8e.html\" scrolling=\"no\" frameborder=\"0\"> </iframe>",
+        "alt-text": "Comcast / Fox / Sky / Disney timeline",
+        "type": "particle"
+      },
+      {
+        "data": "The Takeover Panel is expected to publish the final offers as they are handed over to Sky’s independent directors, who are led by deputy chairman Martin Gilbert, the joint-chief executive of Standard Life Aberdeen. Sky’s chief executive Jeremy Darroch and chief operating officer Andrew Griffith will also assess the bids, alongside the other directors not appointed by Fox.",
+        "html-data": "<p>The Takeover Panel is expected to publish the final offers as they are handed over to Sky’s independent directors, who are led by deputy chairman Martin Gilbert, the joint-chief executive of Standard Life Aberdeen. Sky’s chief executive Jeremy Darroch and chief operating officer Andrew Griffith will also assess the bids, alongside the other directors not appointed by Fox.</p>",
+        "type": "text"
+      },
+      {
+        "data": "The Sky board will then recommend which offer Sky shareholders should accept.",
+        "html-data": "<p>The Sky board will then recommend which offer Sky shareholders should accept.</p>",
+        "type": "text"
+      },
+      {
+        "data": "In a note to Sky staff, Mr Darroch said: “Having three of the world’s best and largest media companies seeking to own Sky is a major and positive endorsement of our strategy and the execution of our plans.",
+        "html-data": "<p>In a note to Sky staff, Mr Darroch said: “Having three of the world’s best and largest media companies seeking to own Sky is a major and positive endorsement of our strategy and the execution of our plans.</p>",
+        "type": "text"
+      },
+      {
+        "data": "“A process like the one announced today doesn’t happen very often and is therefore likely to generate coverage and speculation in the media over the coming days. It is also likely to wrap up sometime over the weekend or early Monday morning and could therefore be outside of normal business hours.”",
+        "html-data": "<p>“A process like the one announced today doesn’t happen very often and is therefore likely to generate coverage and speculation in the media over the coming days. It is also likely to wrap up sometime over the weekend or early Monday morning and could therefore be outside of normal business hours.”</p>",
+        "type": "text"
+      },
+      {
+        "data": "Disney and Fox go into the process at a potential advantage, as Fox already owns 39pc of Sky. If the final offers are similar in price, that could prove decisive, as Sky’s independent directors will be obliged to consider the likelihood of each buyer passing the 50pc shareholder approval threshold required to complete a deal.",
+        "html-data": "<p>Disney and Fox go into the process at a potential advantage, as Fox already owns 39pc of Sky. If the final offers are similar in price, that could prove decisive, as Sky’s independent directors will be obliged to consider the likelihood of each buyer passing the 50pc shareholder approval threshold required to complete a deal.</p>",
+        "type": "text"
+      },
+      {
+        "data": "<iframe layout=\"responsive\" sandbox=\"allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms\" resizable=\"\" src=\"https://cf-particle-html.eip.telegraph.co.uk/dd45dfb8-aca9-4a35-9206-d39e25dbaac2.html\" scrolling=\"no\" frameborder=\"0\"> </iframe>",
+        "alt-text": "Markets Hub - Sky",
+        "type": "particle"
+      },
+      {
+        "data": "While Fox will be on the front lines of the auction, its bidding strategy will effectively be controlled by Disney, which has agreed to buy most of its assets, including its Sky stake, for $71bn following another bid battle with Comcast in the United States. The Murdoch family rocked the media world last year by selling out of global TV and film to focus on US news and sport.",
+        "html-data": "<p>While Fox will be on the front lines of the auction, its bidding strategy will effectively be controlled by Disney, which has agreed to buy most of its assets, including its Sky stake, for $71bn following another bid battle with Comcast in the United States. The Murdoch family rocked the media world last year by <a href=\"https://www.telegraph.co.uk/business/2017/12/14/disney-acquire-fox-assets-39bn/\">selling out of global TV and film</a> to focus on US news and sport.</p>",
+        "type": "text"
+      },
+      {
+        "data": "If Comcast is defeated in the UK, Sky will be owned by Fox for several months before being taken over again by Disney next year.",
+        "html-data": "<p>If Comcast is defeated in the UK, Sky will be owned by Fox for several months before being taken over again by Disney next year.</p>",
+        "type": "text"
+      },
+      {
+        "data": "The dramatic finale of a takeover saga that has run for almost two years ranks as the biggest ever such auction. PTT won control of Cove Energy after Shell dropped out of a head-to-head in 2012. Tata paid £6.2bn in an auction of Corus steel in 2007 against CSN of Brazil.",
+        "html-data": "<p>The dramatic finale of a takeover saga&nbsp;that has run for almost two years ranks as the biggest ever such auction. PTT won control of Cove Energy after Shell dropped out of a head-to-head in 2012. Tata paid £6.2bn in an auction of Corus steel in 2007 against CSN of Brazil.</p>",
+        "type": "text"
+      },
+      {
+        "data": "The competition to buy Sky means it is likely to change hands for more than double its valuation before Fox originally bid £10.75 per share in December 2016, which at the time was a 40pc premium on the market price.",
+        "html-data": "<p>The competition to buy Sky means it is likely to change hands for more than double its valuation before Fox originally bid £10.75 per share in December 2016, which at the time was a 40pc premium on the market price.</p>",
+        "type": "text"
+      },
+      {
+        "data": "Sky’s operating performance also markedly improved as Fox faced a series regulatory hurdles that delayed its plans and opened the door for Comcast to gatecrash.",
+        "html-data": "<p>Sky’s operating performance also markedly improved as Fox faced a series regulatory hurdles that delayed its plans and opened the door for Comcast to gatecrash.</p>",
+        "type": "text"
+      },
+      {
+        "data": "It secured a cheaper deal for Premier League rights after the end of fierce competition with BT and signed a deal to bring Netflix onto its set-top boxes, neutralising what had been viewed as a threat. Meanwhile its Italian operation prevailed in a long football rights war with rival Mediaset Premium.",
+        "html-data": "<p>It secured a cheaper deal for Premier League rights after the end of fierce competition with BT and signed a deal to bring Netflix onto its set-top boxes, neutralising what had been viewed as a threat. Meanwhile its Italian operation prevailed in a long football rights war with rival Mediaset Premium.</p>",
+        "type": "text"
+      },
+      {
+        "data": "Both Disney and Comcast want control of Sky partly as a defence against incursions by the tech giants into entertainment. Its direct relationships with 26 million consumers across Europe are viewed as valuable, along with its technology, brand and customer service operations.",
+        "html-data": "<p>Both Disney and Comcast want control of Sky partly as a defence against incursions by the tech giants into entertainment. Its direct relationships with 26 million consumers across Europe are viewed as valuable, along with its technology, brand and customer service operations.</p>",
+        "type": "text"
+      }
+    ],
+    "gallery": [],
+    "reviews": [],
+    "livestream": []
+  }
+}

--- a/component-test/src/test/resources/storage/mappings/content-33333333-3333-3333-3333-333333333333.json
+++ b/component-test/src/test/resources/storage/mappings/content-33333333-3333-3333-3333-333333333333.json
@@ -1,0 +1,14 @@
+{
+    "priority": "100",
+    "request": {
+        "urlPath": "/ucm-storage-service/content/33333333-3333-3333-3333-333333333333",
+        "method": "GET"
+    },
+    "response":{
+        "status" : 200,
+        "bodyFileName": "content-33333333-3333-3333-3333-333333333333.json",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/component-test/src/test/resources/storage/payload-content1.json
+++ b/component-test/src/test/resources/storage/payload-content1.json
@@ -3,6 +3,7 @@
         "content-id": "11111111-1111-1111-1111-111111111111",
         "type": "article",
         "premium": false,
+        "active":true,
         "language": "en-GB",
         "tmg-created-date": "2017-01-01T12:00:00.000Z",
         "tmg-last-modified-date": "2017-01-01T12:00:00.000Z",
@@ -51,6 +52,7 @@
             {
                 "name": "Fake Author",
                 "uri": "wwww.telegraph.co.uk/fake/author",
+                "url": "wwww.telegraph.co.uk/fake/url",
                 "role": "Fake Journalist",
                 "location": "somewhere"
             }

--- a/component-test/src/test/resources/storage/payload-content2.json
+++ b/component-test/src/test/resources/storage/payload-content2.json
@@ -3,6 +3,7 @@
         "content-id": "22222222-2222-2222-2222-222222222222",
         "type": "article",
         "premium": false,
+        "active":true,
         "language": "en-GB",
         "tmg-created-date": "2016-01-01T12:00:00.000Z",
         "tmg-last-modified-date": "2016-01-01T12:00:00.000Z",
@@ -51,6 +52,7 @@
             {
                 "name": "Fake Author",
                 "uri": "wwww.telegraph.co.uk/fake/author",
+                "url": "wwww.telegraph.co.uk/fake/author/url",
                 "role": "Fake Journalist",
                 "location": "somewhere"
             }

--- a/component-test/src/test/scala/uk/co/telegraph/recommend/articles/article/RecommendArticleSpecs.scala
+++ b/component-test/src/test/scala/uk/co/telegraph/recommend/articles/article/RecommendArticleSpecs.scala
@@ -1,7 +1,6 @@
 package uk.co.telegraph.recommend.articles.article
 
 import io.restassured.module.scala.RestAssuredSupport._
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers._
 import org.hamcrest.Matchers.hasItem
 import uk.co.telegraph.recommend.articles.ComponentTest

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -13,7 +13,7 @@ object Common extends AutoPlugin {
 
     organization      := "uk.co.telegraph",
     version           := "1.0.0-" + buildNumber.getOrElse("SNAPSHOT"),
-    scalaVersion      := "2.11.8",
+    scalaVersion      := "2.12.4",
     isSnapshot        := buildNumber.isEmpty,
     scalacOptions     ++= Seq(
       "-target:jvm-1.8",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,8 @@ import sbt._
 
 object Dependencies {
   val TmgUtils         = "1.0.0-b61"
+  val TmgHttpClient    = "1.1.0-b86"
+  val TmgPlayServerExt = "1.1.0-b77"
   val Json4sVersion    = "3.5.3"
   val PlayVersion      = "2.6.0"
   val AwsSdkVersion    = "1.11.271"
@@ -12,11 +14,11 @@ object Dependencies {
   val ServiceDependencies: Seq[Setting[_]] = Seq(
     libraryDependencies ++= Seq(
       // Telegraph Utils
-      "uk.co.telegraph"              %%  "play-server-ext"              % TmgUtils,
+      "uk.co.telegraph"              %%  "play-server-ext"              % TmgPlayServerExt,
       "uk.co.telegraph"              %%  "generic-client"               % TmgUtils,
-      "uk.co.telegraph"              %%  "http-client"                  % TmgUtils,
+      "uk.co.telegraph"              %%  "http-client"                  % TmgHttpClient,
 
-      "uk.co.telegraph"              %%  "ucm-library"                  % "1.0.0-b21",
+      "uk.co.telegraph"              %%  "ucm-library"                  % "1.1.0-b44",
 
       "com.typesafe.play"            %%  "play"                         % PlayVersion,
       "com.typesafe.play"            %%  "play-guice"                   % PlayVersion,
@@ -26,7 +28,7 @@ object Dependencies {
       // Test dependencies
       "org.scalatest"                %%  "scalatest"                    % ScalaTestVersion % Test,
       "org.scalamock"                %%  "scalamock-scalatest-support"  % "3.6.0"          % Test,
-      "uk.co.telegraph"              %%  "http-client-testkit"          % TmgUtils         % Test,
+      "uk.co.telegraph"              %%  "http-client-testkit"          % TmgHttpClient    % Test,
       "com.typesafe.akka"            %% "akka-stream-testkit"           % AkkaVersion      % Test
     )
   )

--- a/src/main/scala/uk/co/telegraph/recommend/articles/flows/RecommendArticleFlow.scala
+++ b/src/main/scala/uk/co/telegraph/recommend/articles/flows/RecommendArticleFlow.scala
@@ -29,6 +29,7 @@ class RecommendArticleFlowImpl( private val storageClient: StorageClient, val re
       Source.single(scoreMap.keySet)
         .via       ( storageClient.getByIds )
         .mapConcat (_.toList)
+        .filter(_.metadata.active.getOrElse(false))
         .map       ( ucmItem => {
           val contentId = ucmItem.metadata.`content-id`
           val score     = scoreMap.getOrElse( contentId, 0.0 )

--- a/src/test/resources/storage-model/payload-content1.json
+++ b/src/test/resources/storage-model/payload-content1.json
@@ -3,6 +3,7 @@
         "content-id": "11111111-1111-1111-1111-111111111111",
         "type": "article",
         "premium": false,
+        "active":true,
         "language": "en-GB",
         "tmg-created-date": "2017-01-01T12:00:00.000Z",
         "tmg-last-modified-date": "2017-01-01T12:00:00.000Z",
@@ -51,6 +52,7 @@
             {
                 "name": "Fake Author",
                 "uri": "wwww.telegraph.co.uk/fake/author",
+                "url": "wwww.telegraph.co.uk/fake/url",
                 "role": "Fake Journalist",
                 "location": "somewhere"
             }

--- a/src/test/resources/storage-model/payload-content2.json
+++ b/src/test/resources/storage-model/payload-content2.json
@@ -3,6 +3,7 @@
         "content-id": "22222222-2222-2222-2222-222222222222",
         "type": "article",
         "premium": false,
+        "active":true,
         "language": "en-GB",
         "tmg-created-date": "2016-01-01T12:00:00.000Z",
         "tmg-last-modified-date": "2016-01-01T12:00:00.000Z",
@@ -51,6 +52,7 @@
             {
                 "name": "Fake Author",
                 "uri": "wwww.telegraph.co.uk/fake/author",
+                "url": "wwww.telegraph.co.uk/fake/author/url",
                 "role": "Fake Journalist",
                 "location": "somewhere"
             }

--- a/src/test/scala/uk/co/telegraph/recommend/articles/TestData.scala
+++ b/src/test/scala/uk/co/telegraph/recommend/articles/TestData.scala
@@ -33,12 +33,14 @@ trait TestData {
   val sampleZoneDateTimeStr: String        = sampleZoneDateTime
   val sampleContentId1     : String        = "11111111-1111-1111-1111-111111111111"
   val sampleContentId2     : String        = "22222222-2222-2222-2222-222222222222"
+  val sampleContentId3     : String        = "33333333-3333-3333-3333-333333333333"
 
   val sampleContentObj1 = UnifiedContentModel(
     metadata = Metadata(
       `content-id`            = sampleContentId1,
       `type`                  = ContentModelEnum.Article,
       premium                 = false,
+      active                  = Some(true),
       language                = "en-GB",
       `tmg-created-date`      = sampleZoneDateTime,
       `tmg-last-modified-date`= sampleZoneDateTime,
@@ -86,6 +88,7 @@ trait TestData {
       authors = Seq(Author(
         name = "Fake Author",
         uri  = Some("wwww.telegraph.co.uk/fake/author"),
+        url  = Some("wwww.telegraph.co.uk/fake/url"),
         role = Some("Fake Journalist"),
         location = Some("somewhere")
       )),
@@ -113,6 +116,7 @@ trait TestData {
       `content-id`            = sampleContentId2,
       `type`                  = ContentModelEnum.Article,
       premium                 = false,
+      active                  = Some(true),
       language                = "en-GB",
       `tmg-created-date`      = "2016-01-01T12:00:00.000Z",
       `tmg-last-modified-date`= "2016-01-01T12:00:00.000Z",
@@ -160,6 +164,83 @@ trait TestData {
       authors = Seq(Author(
         name = "Fake Author",
         uri  = Some("wwww.telegraph.co.uk/fake/author"),
+        url  = Some("wwww.telegraph.co.uk/fake/author/url"),
+        role = Some("Fake Journalist"),
+        location = Some("somewhere")
+      )),
+      body = Seq(
+        BodyText(
+          data        = Some("first paragraph"),
+          `alt-text`  = None,
+          `html-data` = Some("<p>first paragraph</p>")
+        ),
+        BodyImage(
+          data        = Some("http://www.telegraph.co.uk/first/image2.jpeg"),
+          `alt-text`  = Some("first-image-alt-text"),
+          credit      = Some(""),
+          caption     = Some("First Image"),
+          `html-caption` = Some("<p>first paragraph</p>")
+        )
+      ),
+      gallery    = Seq.empty,
+      reviews    = Seq.empty,
+      livestream = Seq.empty
+    )
+  )
+  val sampleContentObj3 = UnifiedContentModel(
+    metadata = Metadata(
+      `content-id`            = sampleContentId3,
+      `type`                  = ContentModelEnum.Article,
+      premium                 = false,
+      active                  = Some(false),
+      language                = "en-GB",
+      `tmg-created-date`      = "2016-01-01T12:00:00.000Z",
+      `tmg-last-modified-date`= "2016-01-01T12:00:00.000Z",
+      source                  = Some(MetadataSource(
+        `original-source`    = "PA",
+        `original-feed-name` = "PA",
+        `source-id`          = "pa",
+        `created-date`       = Some("2016-01-01T12:00:00.000Z")
+      )),
+      desk                    = Some("Fake Article"),
+      rights                  = Seq(
+        MetadataRights(
+          `copyright-holder`      = Some("copyright-holder"),
+          `copyright-notice`      = Some("copyright-notice"),
+          `use-allowed-from-date` = Some("use-allowed-from-date"),
+          `use-allowed-to-date`   = Some("use-allowed-to-date")
+        )
+      ),
+      location                = Seq(
+        MetadataNameUri(
+          name = "london",
+          uri = Some("www.telegraph.co.uk/london")
+        )
+      ),
+      annotations             = Seq(
+        MetadataNameUri(
+          name = "article",
+          uri = Some("www.telegraph.co.uk/article")
+        )
+      ),
+      extensions              = Seq(
+        MetadataExtension(
+          key   = "channel",
+          value = "sports"
+        ),
+        MetadataExtension(
+          key   = "url",
+          value = "http://www.telegraph.co.uk/news/article-2/"
+        )
+      )
+    ),
+    content = Content(
+      headline = "Fake Headline",
+      byline = Some("By Fake Author"),
+      authors = Seq(Author(
+        name = "Fake Author",
+        uri  = Some("wwww.telegraph.co.uk/fake/author"),
+        url  = Some("wwww.telegraph.co.uk/fake/author/url"),
         role = Some("Fake Journalist"),
         location = Some("somewhere")
       )),
@@ -185,6 +266,7 @@ trait TestData {
 
   val sampleContentIds   = Set(sampleContentId1,  sampleContentId2)
   val sampleContentItems = Seq(sampleContentObj1, sampleContentObj2)
+  val sampleContentIds__containingOneInactiveArticle  = Set(sampleContentId1,  sampleContentId2, sampleContentId3)
 
   val sampleRecommenderRequest = RecommenderRequest(
     channel = Some("News"),
@@ -196,6 +278,15 @@ trait TestData {
     data           = Seq(
       RecommenderItem( sampleContentId1, 0.9, "2017-01-01T12:00:00.000Z"),
       RecommenderItem( sampleContentId2, 0.8, "2016-01-01T12:00:00.000Z")
+    )
+  )
+
+  val sampleRecommenderResponse_containingOneInactiveArticle = RecommenderResponse(
+    `result-count`= 3,
+    data           = Seq(
+      RecommenderItem( sampleContentId1, 0.9, "2017-01-01T12:00:00.000Z"),
+      RecommenderItem( sampleContentId2, 0.8, "2016-01-01T12:00:00.000Z"),
+      RecommenderItem( sampleContentId3, 0.7, "2015-01-01T12:00:00.000Z")
     )
   )
 

--- a/src/test/scala/uk/co/telegraph/recommend/articles/flows/RecommendArticleFlowSpecs.scala
+++ b/src/test/scala/uk/co/telegraph/recommend/articles/flows/RecommendArticleFlowSpecs.scala
@@ -48,7 +48,17 @@ class RecommendArticleFlowSpecs
   )
 
   "Given the 'RecommendArticleFlow'" - {
-    "it should be possible to get recommendations" - {
+    "it should get recommendations" - {
+      "only returns active ucm items" in {
+        mockRecommenderClientFunc.apply _ when sampleRecommenderRequest returns sampleRecommenderResponse_containingOneInactiveArticle once()
+        mockStorageClientFunc.apply     _ when sampleContentIds__containingOneInactiveArticle         returns Seq(sampleContentObj1, sampleContentObj2, sampleContentObj3) once()
+
+        whenReady(recommenderFlow.getRecommendationFor(sampleRecommendArticle)){ res =>
+          println(res)
+          res shouldBe sampleRecommendArticleResult
+        }
+      }
+
       "without applying any filter" in {
         mockRecommenderClientFunc.apply _ when sampleRecommenderRequest returns sampleRecommenderResponse once()
         mockStorageClientFunc.apply     _ when sampleContentIds         returns Seq(sampleContentObj1, sampleContentObj2) once()
@@ -58,7 +68,7 @@ class RecommendArticleFlowSpecs
         }
       }
 
-      "filtering by range date" in {
+      "by filtering by range date" in {
         mockRecommenderClientFunc.apply _ when sampleRecommenderRequest returns sampleRecommenderResponse once()
         mockStorageClientFunc.apply     _ when Set(sampleContentId1)    returns Seq(sampleContentObj1)    once()
 
@@ -67,7 +77,7 @@ class RecommendArticleFlowSpecs
         }
       }
 
-      "filtering with offset and limit" in {
+      "by filtering with offset and limit" in {
         mockRecommenderClientFunc.apply _ when sampleRecommenderRequest returns sampleRecommenderResponse once()
         mockStorageClientFunc.apply     _ when sampleContentIds         returns Seq(sampleContentObj1, sampleContentObj2) once()
 
@@ -76,7 +86,7 @@ class RecommendArticleFlowSpecs
         }
       }
 
-      "filtering by Source" in {
+      "by filtering by Source" in {
         mockRecommenderClientFunc.apply _ when sampleRecommenderRequest returns sampleRecommenderResponse once()
         mockStorageClientFunc.apply     _ when sampleContentIds         returns Seq(sampleContentObj1, sampleContentObj2) once()
 
@@ -85,7 +95,7 @@ class RecommendArticleFlowSpecs
         }
       }
 
-      "filtering by Channel" in {
+      "by filtering by Channel" in {
         mockRecommenderClientFunc.apply _ when sampleRecommenderRequest returns sampleRecommenderResponse once()
         mockStorageClientFunc.apply     _ when sampleContentIds         returns Seq(sampleContentObj1, sampleContentObj2) once()
 


### PR DESCRIPTION
#### Label: ####
**improvement** - Filtering out non-active articles from article recommendation response. 

#### What's this PR do?

#### Where should the reviewer start?

#### What tests were added?

#### Any background context you want to provide?

#### Are there other tickets linked to this?

#### Outstanding questions?

#### Definition of Done:
- [ ] Is there appropriate test coverage?
- [ ] Does the confluence need to be updated?
- [ ] Does this add new dependencies? If so, have the healthchecks been updated?
- [ ] Any Deployment changes we need to be aware of? New infrastructure? Changes to existing components?
- [ ] Is there appropriate logging included?
- [ ] Does it imply any kind of data migration? If so what are the steps for that?
- [ ] Is the Documentation been updated, if needed?
